### PR TITLE
Support downloading markdown files for static targets

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1847,6 +1847,7 @@ function renderDocs(builtPackaged: string, localDir: string) {
             html = html.replace(/(<a[^<>]*)\shref="(\/[^<>"]*)"/g, (f, beg, url) => {
                 return beg + ` href="${webpath}docs${url}.html"`
             })
+            fs.writeFileSync(dd, buf);
             buf = new Buffer(html, "utf8")
             dd = dd.slice(0, dd.length - 3) + ".html"
         }

--- a/pxtlib/emitter/cloud.ts
+++ b/pxtlib/emitter/cloud.ts
@@ -65,7 +65,13 @@ namespace pxt.Cloud {
 
     export function downloadMarkdownAsync(docid: string, locale?: string, live?: boolean): Promise<string> {
         docid = docid.replace(/^\//, "");
-        let url = `md/${pxt.appTarget.id}/${docid}?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;
+        let url: string;
+        if (pxt.webConfig.isStatic) {
+            url= `/${docid}.md?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;
+        }
+        else {
+            url = `md/${pxt.appTarget.id}/${docid}?targetVersion=${encodeURIComponent(pxt.webConfig.targetVersion)}`;
+        }
         if (locale != "en") {
             url += `&lang=${encodeURIComponent(Util.userLanguage())}`
             if (live) url += "&live=1"
@@ -81,6 +87,14 @@ namespace pxt.Cloud {
                     return privateGetTextAsync(url);
                 else return resp.text
             });
+        else if (pxt.webConfig.isStatic) {
+            return Util.requestAsync({
+                url: url,
+                headers: { "Authorization": Cloud.localToken },
+                method: "GET",
+                allowHttpErrors: true
+            }).then(resp => resp.text)
+        }
         else return privateGetTextAsync(url);
     }
 


### PR DESCRIPTION
This is necessary for enabling tutorials in static targets. Basically, it changes `pxt staticpkg` to also emit markdown next to the rendered `.html` files. I also had to change our markdown downloading implementation to make requests to the local server rather than the PXT backend when the target is static.